### PR TITLE
v1.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ minecraft_version=1.21.1
 yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
-neoforge_version=21.1.66
-kff_version=5.3.0
+neoforge_version=21.1.181
+kff_version=5.8.0
 cobblemon_version=1.6.1+1.21.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 loom.platform=neoforge
 
-mod_version=1.6-neoforge-1.1.0
+mod_version=1.6-neoforge-1.1.1
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=capturexp
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/capturexp/CaptureXP.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/capturexp/CaptureXP.kt
@@ -20,7 +20,6 @@ object CaptureXP {
 
     @Suppress("MemberVisibilityCanBePrivate")
     var config: CaptureXPConfig = ConfigBuilder.load(CaptureXPConfig::class.java, MOD_ID)
-    var eventsListening = false
 
     init {
         CobblemonEvents.POKEMON_CAPTURED.subscribe { event ->

--- a/src/main/kotlin/us/timinc/mc/cobblemon/capturexp/CaptureXP.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/capturexp/CaptureXP.kt
@@ -8,10 +8,7 @@ import com.cobblemon.mod.common.api.tags.CobblemonItemTags
 import com.cobblemon.mod.common.pokemon.OriginalTrainerType
 import com.cobblemon.mod.common.pokemon.evolution.requirements.LevelRequirement
 import com.cobblemon.mod.common.util.isInBattle
-import net.neoforged.bus.api.SubscribeEvent
-import net.neoforged.fml.common.EventBusSubscriber
 import net.neoforged.fml.common.Mod
-import net.neoforged.neoforge.event.server.ServerStartedEvent
 import us.timinc.mc.cobblemon.capturexp.config.CaptureXPConfig
 import us.timinc.mc.cobblemon.capturexp.config.ConfigBuilder
 import kotlin.math.pow
@@ -25,15 +22,9 @@ object CaptureXP {
     var config: CaptureXPConfig = ConfigBuilder.load(CaptureXPConfig::class.java, MOD_ID)
     var eventsListening = false
 
-    @EventBusSubscriber()
-    object Registration {
-        @SubscribeEvent
-        fun onInit(e: ServerStartedEvent) {
-            if (eventsListening) return
-            eventsListening = true
-            CobblemonEvents.POKEMON_CAPTURED.subscribe { event ->
-                if (event.player.isInBattle()) handleCaptureInBattle(event) else handleCaptureOutOfBattle(event)
-            }
+    init {
+        CobblemonEvents.POKEMON_CAPTURED.subscribe { event ->
+            if (event.player.isInBattle()) handleCaptureInBattle(event) else handleCaptureOutOfBattle(event)
         }
     }
 

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,7 +4,7 @@ license = "MIT"
 
 [[mods]]
 modId = "capture_xp"
-version = "1.6-neoforge-1.1.0"
+version = "1.6-neoforge-1.1.1"
 displayName = "Cobblemon Capture XP"
 authors = "timinc aka Timothy Metcalfe"
 description = '''


### PR DESCRIPTION
* Moved event handler registration from annotations to init. Change precipitated by an oddity in newer versions of KFF/NF that caused annotation-based event registration to fail (looks like NF removed access to something? idk). This should work across versions.